### PR TITLE
feat: publishes to npm upon github releases

### DIFF
--- a/.github/workflows/publsh-to-npm.yml
+++ b/.github/workflows/publsh-to-npm.yml
@@ -1,0 +1,19 @@
+name: Publish Package to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "16.x"
+          registry-url: "https://registry.npmjs.org"
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### Publish the code base to npm

upon a new version being published, this github action will create a release in npm. Meaning that a new version of package will be live in npm. 

### Pre-requisities
1. [Get NPM access token](https://docs.npmjs.com/creating-and-viewing-access-tokens)
2. [Put the token in the secrets with](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions)  `NPM_TOKEN` secrets variable.
3. 